### PR TITLE
Add use warnings;

### DIFF
--- a/lib/POE/Loop/EV.pm
+++ b/lib/POE/Loop/EV.pm
@@ -3,6 +3,7 @@ package POE::Loop::EV;
 # EV.pm (libev) event loop bridge
 # $Id: EV.pm 27 2008-01-29 19:42:57Z andyg $
 
+use warnings;
 use strict;
 use POE::Loop::PerlSignals;
 


### PR DESCRIPTION
Recomendation from CPANTS:

http://cpants.cpanauthors.org/dist/POE-Loop-EV

```
use_warnings
Add 'use warnings' (or its equivalents) to all modules (this will require
perl > 5.6), or convince us that your favorite module is well-known enough
and people can easily see the modules warn when something bad happens.

Error: POE::Loop::EV
```

This PR belong to my montly PR-Challenge